### PR TITLE
add tolerance to collision checking and fix out-of-bound check

### DIFF
--- a/packages/@frograming/frogger/src/models/Board.js
+++ b/packages/@frograming/frogger/src/models/Board.js
@@ -136,7 +136,7 @@ export default class Board {
 
   isFrogOutOfBoard () {
     const { frog } = this;
-    return frog.pos.x < 0 || frog.pos.x >= MAX_X + 1 || frog.pos.y < 0 || frog.pos.y >= MAX_Y + 1;
+    return frog.pos.x <= -1 || frog.pos.x >= MAX_X + 1 || frog.pos.y <= -1 || frog.pos.y >= MAX_Y + 1;
   }
 
   hasFrogTouchdown () {

--- a/packages/@frograming/frogger/src/models/Obstacles.js
+++ b/packages/@frograming/frogger/src/models/Obstacles.js
@@ -11,6 +11,9 @@ const nextUid = (() => {
   return () => uid++;
 })();
 
+const FROG_WIDTH = 1;
+const TOLERANCE_THRESHOLD = 0.15;
+
 class AbstractObstacle {
   type = 'abstract-obstacle';
 
@@ -45,12 +48,12 @@ class AbstractObstacle {
 
   overlapsWith ({x, y}) {
     const { pos, length } = this;
-    return y === pos.y && isInRange(x, [pos.x - 1, pos.x + length], '()');
+    return y === pos.y && isInRange(x, [pos.x - FROG_WIDTH + TOLERANCE_THRESHOLD, pos.x + length - TOLERANCE_THRESHOLD], '()');
   }
 
   contains ({x, y}) {
     const { pos, length } = this;
-    return y === pos.y && isInRange(x, [pos.x, round(pos.x + length - 1, 5)], '[]');
+    return y === pos.y && isInRange(x, [pos.x - TOLERANCE_THRESHOLD, round(pos.x + length - FROG_WIDTH, 5) + TOLERANCE_THRESHOLD], '[]');
   }
 }
 


### PR DESCRIPTION
This PR contains: 

1. Added a `TOLERANCE_THRESHOLD` to make collision checking less strict. (after all the frog should be able to balance on the log even with a leg in the water)

2. Fixing logic for out of bound. `frog.pos.x < 0` and `frog.pos.y <0` only checks if part of the frog is out of the board. `<= -1` will check if the frog is totally out.